### PR TITLE
set optional to true for belongs_to owner association

### DIFF
--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -7,7 +7,12 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
   before_create :generate_unique_key
 
   # allows the shortened link to be associated with a user
-  belongs_to :owner, polymorphic: true
+  if ActiveRecord::VERSION::MAJOR >= 5
+    # adds rails 5 compatibility to have nil values as owner
+    belongs_to :owner, polymorphic: true, optional: true
+  else
+    belongs_to :owner, polymorphic: true
+  end
 
   # exclude records in which expiration time is set and expiration time is greater than current time
   scope :unexpired, -> { where(arel_table[:expires_at].eq(nil).or(arel_table[:expires_at].gt(::Time.current.to_s(:db)))) }

--- a/spec/dummy/config/initializers/new_framework_default.rb
+++ b/spec/dummy/config/initializers/new_framework_default.rb
@@ -1,0 +1,11 @@
+# This file extends the new Rails (aka version 5) framework default initializers.
+# It sets the application defaults therefore and because of this dummy application
+# supports new version should contain this file.
+# It isn't adding all defaults as the rails 5 does because of 5.1 and 5.2
+# contains different settings, therefore, it is scoping the settings that this gem
+# requires.
+if ActiveRecord::VERSION::MAJOR >= 5
+  # Require `belongs_to` associations by default. Previous versions had false.
+  Rails.application.config.active_record.belongs_to_required_by_default = true
+end
+


### PR DESCRIPTION
#### what?
 
It fixes the rails 5 issue when try to create a shorted url without owner

#### status?

Tests pending due an issue with shared example